### PR TITLE
Fixed config that prevented the DB from working on localhost

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,13 +20,13 @@ default: &default
     host: db
     username: postgres
     password:
-    # For details on connection pooling, see Rails configuration guide
-    # http://guides.rubyonrails.org/configuring.html#database-pooling
     pool: 5
 
-development:
-    <<: *default
+development: &development
+    adapter: postgresql
+    encoding: unicode
     database: SeeQL_development
+    pool: 5
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -59,7 +59,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-    <<: *default
+    <<: *development
     database: SeeQL_test
 
 # As with config/secrets.yml, you never want to store sensitive information,


### PR DESCRIPTION
The `Docker` config was preventing the DB from working with `localhost`. This is now fixed.